### PR TITLE
feat: add Rails 8 compatibility

### DIFF
--- a/pricing_plans.gemspec
+++ b/pricing_plans.gemspec
@@ -35,8 +35,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Core dependencies
-  spec.add_dependency "activerecord", "~> 7.1", ">= 7.1.0"
-  spec.add_dependency "activesupport", "~> 7.1", ">= 7.1.0"
+  spec.add_dependency "activerecord", ">= 7.1.0", "< 9.0"
+  spec.add_dependency "activesupport", ">= 7.1.0", "< 9.0"
 
   # Development dependencies
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
- Update activerecord dependency to support >= 7.1.0, < 9.0
- Update activesupport dependency to support >= 7.1.0, < 9.0
- Maintains backward compatibility with Rails 7.1

🤖 Generated with [Claude Code](https://claude.ai/code)