### PR TITLE
Prevent granting unlimited access to undefined limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ Enforce pricing plan limits with one-liners that read like plain English. Avoid 
 For example, this is how you define pricing plans and their entitlements:
 ```ruby
 plan :pro do
-  allows :api_access
-  limits :projects, to: 5
+  allows :api_access      # Features: blocked by default unless explicitly allowed
+  limits :projects, to: 5 # Limits: 0 by default unless a limit is set explicitly
 end
 ```
+
+Plans are **secure by default**: features are disabled and limits are set to 0 unless explicitly configured.
 
 You can then gate features in your controllers:
 ```ruby

--- a/docs/01-define-pricing-plans.md
+++ b/docs/01-define-pricing-plans.md
@@ -20,7 +20,9 @@ That's the basics! Let's dive in.
 
 ## Define what each plan gives
 
-At a high level, a plan needs to do **two** things:
+Plans are **secure by default**: features are disabled and limits are set to 0 unless explicitly configured.
+
+At a high level, a plan does **two** things:
   (1) Gate features
   (2) Enforce limits (quotas)
 
@@ -41,7 +43,7 @@ end
 We're just **defining** what the plan does now. Later, we'll see [all the methods we can use to enforce these limits and gate these features](#gate-features-in-controllers) very easily.
 
 
-All features are disabled by default unless explicitly made available with the `allows` keyword. However, for clarity we can explicitly say what the plan disallows:
+**Features and limits are secure by default**: features are disabled and limits are set to 0 unless explicitly allowed. For clarity, you can explicitly state what a plan disallows, but this is just cosmetic:
 
 ```ruby
 PricingPlans.configure do |config|
@@ -252,16 +254,15 @@ end
 
 (Assuming, of course, that your `Project` model has an `active` scope)
 
-You can also make something unlimited (again, just syntactic sugar to be explicit, everything is unlimited unless there's an actual limit):
+**Undefined limits default to 0 (blocked).** To explicitly allow unlimited access, use the `unlimited` helper:
 
 ```ruby
 PricingPlans.configure do |config|
-  plan :free do
-    price 0
-
+  plan :enterprise do
+    price 999
     allows :api_access
-
-    unlimited :projects
+    unlimited :projects  # Explicit unlimited
+    # :storage undefined → 0 (blocked)
   end
 end
 ```
@@ -331,9 +332,7 @@ PricingPlans.configure do |config|
     price 0
     hidden!  # Won't appear on pricing page
     default!
-
-    limit :projects, to: 0
-    limit :api_calls, to: 0, per: :month
+    # No limits defined - everything defaults to 0 (blocked)
   end
 
   # Visible plans for your pricing page

--- a/lib/pricing_plans/controller_guards.rb
+++ b/lib/pricing_plans/controller_guards.rb
@@ -188,9 +188,10 @@ module PricingPlans
       plan = PlanResolver.effective_plan_for(plan_owner)
       limit_config = plan&.limit_for(limit_key)
 
-      # If no limit is configured, allow the action
+      # BREAKING CHANGE: If no limit is configured, block the action (secure by default)
+      # Previously this returned :within (allowed), now returns :blocked
       unless limit_config
-        return Result.within("No limit configured for #{limit_key}")
+        return Result.blocked("Limit #{limit_key.to_s.humanize.downcase} not configured on this plan")
       end
 
       # Check if unlimited

--- a/lib/pricing_plans/limit_checker.rb
+++ b/lib/pricing_plans/limit_checker.rb
@@ -20,7 +20,9 @@ module PricingPlans
       def remaining(plan_owner, limit_key)
         plan = PlanResolver.effective_plan_for(plan_owner)
         limit_config = plan&.limit_for(limit_key)
-        return :unlimited unless limit_config
+        # BREAKING CHANGE: Undefined limits now default to 0 (blocked) instead of :unlimited
+        # This is secure-by-default: if a plan doesn't define a limit, access is blocked
+        return 0 unless limit_config
 
         limit_amount = limit_config[:to]
         return :unlimited if limit_amount == :unlimited
@@ -54,7 +56,8 @@ module PricingPlans
       def limit_amount(plan_owner, limit_key)
         plan = PlanResolver.effective_plan_for(plan_owner)
         limit_config = plan&.limit_for(limit_key)
-        return :unlimited unless limit_config
+        # BREAKING CHANGE: Undefined limits now default to 0 (blocked) instead of :unlimited
+        return 0 unless limit_config
 
         limit_config[:to]
       end

--- a/test/controller_guards_test.rb
+++ b/test/controller_guards_test.rb
@@ -18,8 +18,9 @@ class ControllerGuardsTest < ActiveSupport::TestCase
     PricingPlans::PlanResolver.stub(:effective_plan_for, plan) do
       result = require_plan_limit!(:non_existent, plan_owner: @org)
 
-      assert result.within?
-      assert_match(/no limit configured/i, result.message)
+      # BREAKING CHANGE: Undefined limits now block instead of allowing
+      assert result.blocked?
+      assert_match(/not configured/i, result.message)
     end
   end
 

--- a/test/hidden_plans_test.rb
+++ b/test/hidden_plans_test.rb
@@ -503,7 +503,7 @@ class HiddenPlansTest < ActiveSupport::TestCase
   # ========================================
 
   def test_real_world_use_case_unsubscribed_users_dont_see_hidden_plan_on_pricing_page
-    # This test simulates the iconprinter use case
+    # This test simulates the demobusiness use case
     PricingPlans.configure do |config|
       config.plan_owner_class = "Organization"
 

--- a/test/secure_by_default_test.rb
+++ b/test/secure_by_default_test.rb
@@ -1,0 +1,526 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# COMPREHENSIVE TESTS: Secure-by-Default Behavior for Undefined Limits
+#
+# This test file documents and enforces the BREAKING CHANGE introduced to make
+# undefined limits default to 0 (blocked) instead of :unlimited (fail-open).
+#
+# PHILOSOPHY: Fail-closed (secure) by default
+# - Features: blocked unless explicitly allowed with `allows`
+# - Limits: blocked unless explicitly defined with `limit` or `unlimited`
+#
+# This consistency ensures developers must explicitly grant access, preventing
+# security issues from forgotten/undefined limits.
+#
+# REAL-WORLD USE CASE: Hidden unsubscribed plans for all-paid products
+# Example: demobusiness.com wants unsubscribed users to have zero access without
+# seeing an "Unsubscribed" plan on the pricing page. The hidden default plan
+# achieves this elegantly without inadvertently granting unlimited access.
+
+class SecureByDefaultTest < ActiveSupport::TestCase
+  def setup
+    super
+    PricingPlans.reset_configuration!
+  end
+
+  # ========================================
+  # SECTION 1: UNDEFINED LIMITS = BLOCKED
+  # ========================================
+
+  def test_undefined_limits_default_to_zero_not_unlimited
+    PricingPlans.configure do |config|
+      config.plan_owner_class = "Organization"
+
+      config.plan :starter do
+        price 10
+        default!
+        # No limits defined at all
+      end
+    end
+
+    org = Organization.create!(name: "Test Org")
+    PricingPlans::PlanResolver.assign_plan_manually!(org, :starter)
+
+    # SECURITY: Undefined limits are BLOCKED (0), not unlimited
+    assert_equal 0, org.plan_limit_remaining(:projects)
+    assert_equal 0, org.plan_limit_remaining(:api_calls)
+    assert_equal 0, org.plan_limit_remaining(:storage)
+    assert_equal 0, org.plan_limit_remaining(:any_undefined_limit)
+
+    # within_limit? returns false for undefined limits
+    refute org.within_plan_limits?(:projects)
+    refute org.within_plan_limits?(:api_calls, by: 1)
+    refute org.within_plan_limits?(:storage, by: 100)
+  end
+
+  def test_undefined_limits_match_undefined_features_behavior
+    PricingPlans.configure do |config|
+      config.plan_owner_class = "Organization"
+
+      config.plan :basic do
+        price 5
+        default!
+        # No features defined
+        # No limits defined
+      end
+    end
+
+    org = Organization.create!(name: "Test Org")
+    PricingPlans::PlanResolver.assign_plan_manually!(org, :basic)
+
+    # CONSISTENCY: Both features and limits are fail-closed (blocked by default)
+
+    # Undefined features are blocked
+    refute org.plan_allows?(:advanced_analytics), "Undefined features should be blocked"
+    refute org.plan_allows?(:priority_support), "Undefined features should be blocked"
+    refute org.plan_allows?(:api_access), "Undefined features should be blocked"
+
+    # Undefined limits are blocked (matching behavior)
+    refute org.within_plan_limits?(:projects), "Undefined limits should be blocked"
+    refute org.within_plan_limits?(:users), "Undefined limits should be blocked"
+    refute org.within_plan_limits?(:storage), "Undefined limits should be blocked"
+
+    # This is SECURE BY DEFAULT - developers must explicitly grant access
+  end
+
+  def test_explicit_unlimited_still_works
+    PricingPlans.configure do |config|
+      config.plan_owner_class = "Organization"
+
+      config.plan :enterprise do
+        price 999
+        default!
+        unlimited :projects, :users, :storage  # Explicit unlimited
+        limit :api_calls, to: 100_000, per: :month  # Explicit limit
+        # :downloads undefined - should be blocked
+      end
+    end
+
+    org = Organization.create!(name: "Enterprise Org")
+    PricingPlans::PlanResolver.assign_plan_manually!(org, :enterprise)
+
+    # Explicit unlimited works
+    assert_equal :unlimited, org.plan_limit_remaining(:projects)
+    assert_equal :unlimited, org.plan_limit_remaining(:users)
+    assert_equal :unlimited, org.plan_limit_remaining(:storage)
+    assert org.within_plan_limits?(:projects, by: 999_999)
+
+    # Explicit limit works
+    assert_equal 100_000, org.plan_limit_remaining(:api_calls)
+
+    # Undefined limit is blocked
+    assert_equal 0, org.plan_limit_remaining(:downloads)
+    refute org.within_plan_limits?(:downloads)
+  end
+
+  # ========================================
+  # SECTION 2: REAL-WORLD USE CASE
+  # Hidden Unsubscribed Plan (demobusiness)
+  # ========================================
+
+  def test_demobusiness_use_case_hidden_unsubscribed_plan_blocks_everything
+    # REAL SCENARIO: All-paid product where unsubscribed users should have zero access
+    # The unsubscribed plan is hidden (not shown on pricing page) and blocks everything by default
+    PricingPlans.configure do |config|
+      config.plan_owner_class = "Organization"
+
+      # Hidden default plan - no limits defined, everything blocked by default
+      config.plan :unsubscribed do
+        name "Pending Subscription"
+        description "Subscribe to a plan to get started"
+        price 0
+        hidden!
+        default!
+        # CRITICAL: No limits defined here
+        # Before breaking change: would have been unlimited (security issue!)
+        # After breaking change: everything is blocked (secure!)
+      end
+
+      config.plan :starter do
+        name "Starter"
+        price 29
+        limit :projects, to: 10
+        limit :downloads, to: 1000, per: :month
+        limit :storage, to: 5.gigabytes
+        highlighted!
+      end
+
+      config.plan :pro do
+        name "Pro"
+        price 99
+        limit :projects, to: 100
+        unlimited :downloads
+        limit :storage, to: 100.gigabytes
+      end
+    end
+
+    # New user signs up (no subscription yet)
+    new_user_org = Organization.create!(name: "New User Org")
+
+    # Should be on hidden :unsubscribed plan (default)
+    assert_equal :unsubscribed, new_user_org.current_pricing_plan.key
+    assert new_user_org.current_pricing_plan.hidden?
+
+    # SECURITY: All limits are blocked (0) since none were defined
+    assert_equal 0, new_user_org.plan_limit_remaining(:projects), "Unsubscribed users should have 0 projects"
+    assert_equal 0, new_user_org.plan_limit_remaining(:downloads), "Unsubscribed users should have 0 downloads"
+    assert_equal 0, new_user_org.plan_limit_remaining(:storage), "Unsubscribed users should have 0 storage"
+
+    # Cannot perform any actions
+    refute new_user_org.within_plan_limits?(:projects), "Cannot create projects"
+    refute new_user_org.within_plan_limits?(:downloads, by: 1), "Cannot download"
+    refute new_user_org.within_plan_limits?(:storage, by: 1.megabyte), "Cannot use storage"
+
+    # :unsubscribed plan is NOT shown on pricing page
+    pricing_plans = PricingPlans.for_pricing(plan_owner: new_user_org)
+    assert_equal 2, pricing_plans.size
+    assert_equal [:starter, :pro], pricing_plans.map { |p| p[:key] }
+    refute pricing_plans.any? { |p| p[:key] == :unsubscribed }
+
+    # After subscribing to starter, limits become available
+    PricingPlans::PlanResolver.assign_plan_manually!(new_user_org, :starter)
+    assert_equal 10, new_user_org.plan_limit_remaining(:projects)
+    assert_equal 1000, new_user_org.plan_limit_remaining(:downloads)
+    assert new_user_org.within_plan_limits?(:projects)
+  end
+
+  def test_forgotten_limit_is_blocked_not_unlimited
+    # SECURITY SCENARIO: Developer forgets to define a limit in a plan
+    PricingPlans.configure do |config|
+      config.plan_owner_class = "Organization"
+
+      config.plan :premium do
+        price 49
+        default!
+        limit :projects, to: 50
+        limit :users, to: 10
+        # OOPS: Developer forgot to define :api_calls limit!
+        # Before: Would have been :unlimited (security issue!)
+        # After: Is blocked (secure!)
+      end
+    end
+
+    org = Organization.create!(name: "Premium Org")
+    PricingPlans::PlanResolver.assign_plan_manually!(org, :premium)
+
+    # Defined limits work
+    assert_equal 50, org.plan_limit_remaining(:projects)
+    assert_equal 10, org.plan_limit_remaining(:users)
+
+    # Forgotten limit is BLOCKED, not unlimited
+    assert_equal 0, org.plan_limit_remaining(:api_calls), "Forgotten limits should be blocked"
+    refute org.within_plan_limits?(:api_calls), "Forgotten limits should block access"
+  end
+
+  # ========================================
+  # SECTION 3: CONTROLLER ENFORCEMENT
+  # ========================================
+
+  def test_controller_guards_block_undefined_limits
+    PricingPlans.configure do |config|
+      config.plan_owner_class = "Organization"
+
+      config.plan :basic do
+        price 10
+        default!
+        limit :projects, to: 5
+        # :exports undefined
+      end
+    end
+
+    org = Organization.create!(name: "Test Org")
+    PricingPlans::PlanResolver.assign_plan_manually!(org, :basic)
+
+    # Simulate controller context
+    controller = MockController.new
+    controller.instance_variable_set(:@org, org)
+    controller.extend(PricingPlans::ControllerGuards)
+
+    # Defined limit - should work
+    result_projects = controller.require_plan_limit!(:projects, plan_owner: org)
+    assert result_projects.within?, "Defined limits should allow access when within limit"
+
+    # Undefined limit - should be BLOCKED
+    result_exports = controller.require_plan_limit!(:exports, plan_owner: org)
+    assert result_exports.blocked?, "Undefined limits should block access"
+    assert_match(/not configured/i, result_exports.message)
+  end
+
+  # ========================================
+  # SECTION 4: MODEL VALIDATIONS
+  # ========================================
+
+  def test_model_validations_block_creation_when_limit_undefined
+    PricingPlans.configure do |config|
+      config.plan_owner_class = "Organization"
+
+      config.plan :trial do
+        price 0
+        default!
+        # No :projects limit defined
+      end
+    end
+
+    org = Organization.create!(name: "Trial Org")
+    PricingPlans::PlanResolver.assign_plan_manually!(org, :trial)
+
+    # Try to create a project (which has limited_by_pricing_plans validation)
+    # When limit is undefined (0), attempting to create should be blocked
+    project = org.projects.build(name: "Test Project")
+
+    # Validation should fail because remaining is 0 (undefined limit)
+    refute project.valid?, "Should fail validation when limit is undefined (0 remaining)"
+
+    # The error comes from the limit validation
+    assert project.errors.any?, "Should have validation errors"
+    assert_includes project.errors.full_messages.join.downcase, "projects", "Error should mention projects limit"
+  end
+
+  def test_model_validations_allow_creation_when_limit_defined
+    PricingPlans.configure do |config|
+      config.plan_owner_class = "Organization"
+
+      config.plan :trial do
+        price 0
+        default!
+        limit :projects, to: 3
+      end
+    end
+
+    org = Organization.create!(name: "Trial Org")
+    PricingPlans::PlanResolver.assign_plan_manually!(org, :trial)
+
+    # Should succeed when limit is defined and not exceeded
+    project = org.projects.create!(name: "Test Project")
+    assert project.persisted?, "Should allow creation when limit is defined and within limit"
+  end
+
+  # ========================================
+  # SECTION 5: EDGE CASES & SECURITY
+  # ========================================
+
+  def test_partially_defined_limits_only_allow_defined_ones
+    PricingPlans.configure do |config|
+      config.plan_owner_class = "Organization"
+
+      config.plan :mixed do
+        price 20
+        default!
+        limit :projects, to: 10  # Defined
+        unlimited :users  # Defined as unlimited
+        # :api_calls undefined
+        # :storage undefined
+      end
+    end
+
+    org = Organization.create!(name: "Mixed Org")
+    PricingPlans::PlanResolver.assign_plan_manually!(org, :mixed)
+
+    # Defined limit works
+    assert_equal 10, org.plan_limit_remaining(:projects)
+    assert org.within_plan_limits?(:projects)
+
+    # Defined unlimited works
+    assert_equal :unlimited, org.plan_limit_remaining(:users)
+    assert org.within_plan_limits?(:users, by: 999_999)
+
+    # Undefined limits are blocked
+    assert_equal 0, org.plan_limit_remaining(:api_calls)
+    assert_equal 0, org.plan_limit_remaining(:storage)
+    refute org.within_plan_limits?(:api_calls)
+    refute org.within_plan_limits?(:storage)
+  end
+
+  def test_no_plan_assigned_defaults_to_blocked
+    PricingPlans.configure do |config|
+      config.plan_owner_class = "Organization"
+
+      config.plan :starter do
+        price 10
+        default!
+        limit :projects, to: 5
+        # :api_calls undefined
+      end
+    end
+
+    org = Organization.create!(name: "No Plan Org")
+    # Org automatically gets default plan (:starter)
+
+    # Defined limit in default plan works
+    assert_equal 5, org.plan_limit_remaining(:projects)
+
+    # Undefined limits are still blocked even in default plan
+    assert_equal 0, org.plan_limit_remaining(:api_calls)
+    refute org.within_plan_limits?(:api_calls)
+  end
+
+  def test_suggest_next_plan_skips_hidden_unsubscribed_plan
+    PricingPlans.configure do |config|
+      config.plan_owner_class = "Organization"
+
+      config.plan :unsubscribed do
+        price 0
+        hidden!
+        default!
+        # No limits defined
+      end
+
+      config.plan :starter do
+        price 29
+        limit :projects, to: 10
+      end
+
+      config.plan :pro do
+        price 99
+        limit :projects, to: 100
+      end
+    end
+
+    org = Organization.create!(name: "New Org")
+    # Org is on :unsubscribed (hidden, default)
+
+    # suggest_next_plan_for should suggest :starter, not stay on hidden :unsubscribed
+    suggested = PricingPlans.suggest_next_plan_for(org, keys: [:projects])
+    assert_equal :starter, suggested.key, "Should suggest visible plan, not hidden unsubscribed"
+    refute suggested.hidden?
+  end
+
+  # ========================================
+  # SECTION 6: COMPARISON TABLE
+  # (Documented as test for future reference)
+  # ========================================
+
+  def test_behavior_comparison_table_undefined_vs_defined
+    # This test documents expected behavior across all scenarios
+    PricingPlans.configure do |config|
+      config.plan_owner_class = "Organization"
+
+      config.plan :comprehensive do
+        price 50
+        default!
+        # Features
+        allows :feature_a  # Defined feature: allowed
+        disallows :feature_b  # Defined feature: disallowed
+        # :feature_c undefined
+
+        # Limits
+        limit :limit_a, to: 10  # Defined limit
+        unlimited :limit_b  # Defined as unlimited
+        limit :limit_c, to: 0  # Defined as zero
+        # :limit_d undefined
+      end
+    end
+
+    org = Organization.create!(name: "Comprehensive Org")
+    PricingPlans::PlanResolver.assign_plan_manually!(org, :comprehensive)
+
+    # FEATURES
+    assert org.plan_allows?(:feature_a), "Defined allowed feature = true"
+    refute org.plan_allows?(:feature_b), "Defined disallowed feature = false"
+    refute org.plan_allows?(:feature_c), "Undefined feature = false (fail-closed)"
+
+    # LIMITS
+    assert_equal 10, org.plan_limit_remaining(:limit_a), "Defined limit = limit value"
+    assert_equal :unlimited, org.plan_limit_remaining(:limit_b), "Defined unlimited = :unlimited"
+    assert_equal 0, org.plan_limit_remaining(:limit_c), "Defined as 0 = 0"
+    assert_equal 0, org.plan_limit_remaining(:limit_d), "Undefined limit = 0 (fail-closed)"
+
+    # WITHIN LIMITS
+    assert org.within_plan_limits?(:limit_a), "Within defined limit = true"
+    assert org.within_plan_limits?(:limit_b), "Within unlimited = true"
+    refute org.within_plan_limits?(:limit_c), "Within limit of 0 = false"
+    refute org.within_plan_limits?(:limit_d), "Within undefined limit = false"
+
+    # BEHAVIOR TABLE (for documentation):
+    # ┌─────────────────────┬──────────────────┬─────────────────┬──────────────────┐
+    # │ Type                │ Defined: Allowed │ Defined: Blocked│ Undefined        │
+    # ├─────────────────────┼──────────────────┼─────────────────┼──────────────────┤
+    # │ Features            │ allows :x → true │ disallows :x    │ false (blocked)  │
+    # │                     │                  │ → false         │                  │
+    # ├─────────────────────┼──────────────────┼─────────────────┼──────────────────┤
+    # │ Limits              │ limit :x, to: N  │ limit :x, to: 0 │ 0 (blocked)      │
+    # │                     │ → N              │ → 0             │                  │
+    # │                     │ unlimited :x     │                 │                  │
+    # │                     │ → :unlimited     │                 │                  │
+    # └─────────────────────┴──────────────────┴─────────────────┴──────────────────┘
+    #
+    # KEY INSIGHT: Both features and limits are FAIL-CLOSED (secure by default)
+  end
+
+  # ========================================
+  # SECTION 7: MIGRATION SCENARIOS
+  # ========================================
+
+  def test_migration_from_implicit_unlimited_to_explicit
+    # SCENARIO: Existing app had undefined limits that were implicitly unlimited
+    # MIGRATION: Must add explicit `unlimited` for those limits
+    PricingPlans.configure do |config|
+      config.plan_owner_class = "Organization"
+
+      config.plan :legacy do
+        price 99
+        default!
+        limit :projects, to: 100
+        # Before: :api_calls was undefined → :unlimited (implicit)
+        # After migration: Must be explicit
+        unlimited :api_calls  # ADDED: Make implicit unlimited explicit
+      end
+    end
+
+    org = Organization.create!(name: "Legacy Org")
+    PricingPlans::PlanResolver.assign_plan_manually!(org, :legacy)
+
+    # After migration, :api_calls is still unlimited (but explicit)
+    assert_equal :unlimited, org.plan_limit_remaining(:api_calls)
+    assert org.within_plan_limits?(:api_calls, by: 999_999)
+  end
+
+  def test_new_restrictive_plan_benefits_from_secure_default
+    # SCENARIO: New restrictive plan wants to block everything except specific limits
+    # BENEFIT: No need to define every limit as 0, just define the allowed ones
+    PricingPlans.configure do |config|
+      config.plan_owner_class = "Organization"
+
+      config.plan :restrictive do
+        price 0
+        default!
+        limit :projects, to: 1  # Only allow 1 project
+        # Everything else undefined → blocked automatically
+        # Before: Would need to define every limit as 0
+        # After: Secure by default!
+      end
+    end
+
+    org = Organization.create!(name: "Restrictive Org")
+    PricingPlans::PlanResolver.assign_plan_manually!(org, :restrictive)
+
+    # Defined limit works
+    assert_equal 1, org.plan_limit_remaining(:projects)
+
+    # Everything else is blocked automatically
+    assert_equal 0, org.plan_limit_remaining(:users)
+    assert_equal 0, org.plan_limit_remaining(:api_calls)
+    assert_equal 0, org.plan_limit_remaining(:storage)
+    assert_equal 0, org.plan_limit_remaining(:downloads)
+    assert_equal 0, org.plan_limit_remaining(:exports)
+    # ... no need to define every possible limit as 0!
+  end
+
+  # ========================================
+  # HELPER CLASS
+  # ========================================
+
+  class MockController
+    attr_accessor :org
+
+    def pricing_plans_plan_owner
+      @org
+    end
+
+    def respond_to?(method_name)
+      [:pricing_plans_plan_owner].include?(method_name) || super
+    end
+  end
+end

--- a/test/services/limit_checker_more_test.rb
+++ b/test/services/limit_checker_more_test.rb
@@ -8,10 +8,11 @@ class LimitCheckerMoreTest < ActiveSupport::TestCase
     @org = create_organization
   end
 
-  def test_remaining_returns_unlimited_when_no_limit_configured
-    # For an unknown limit key, remaining should be :unlimited
-    assert_equal :unlimited, PricingPlans::LimitChecker.plan_limit_remaining(@org, :unknown_limit)
-    assert PricingPlans::LimitChecker.within_limit?(@org, :unknown_limit)
+  def test_remaining_returns_zero_when_no_limit_configured
+    # BREAKING CHANGE: For an unknown limit key, remaining should be 0 (blocked)
+    # This is secure-by-default: undefined limits block access
+    assert_equal 0, PricingPlans::LimitChecker.plan_limit_remaining(@org, :unknown_limit)
+    refute PricingPlans::LimitChecker.within_limit?(@org, :unknown_limit)
   end
 
   def test_after_limit_action_default_when_no_limit_configured

--- a/test/services/limit_checker_test.rb
+++ b/test/services/limit_checker_test.rb
@@ -258,7 +258,8 @@ class LimitCheckerTest < ActiveSupport::TestCase
 
     # Mock PlanResolver to return nil
     PricingPlans::PlanResolver.stub(:effective_plan_for, nil) do
-      assert_equal :unlimited, PricingPlans::LimitChecker.plan_limit_remaining(org, :projects)
+      # BREAKING CHANGE: Undefined limits now default to 0 (blocked) instead of :unlimited
+      assert_equal 0, PricingPlans::LimitChecker.plan_limit_remaining(org, :projects)
       assert_equal 0.0, PricingPlans::LimitChecker.plan_limit_percent_used(org, :projects)
       assert_equal :block_usage, PricingPlans::LimitChecker.after_limit_action(org, :projects)
     end


### PR DESCRIPTION
This PR removes a critical bug / bad behavior the gem had: when a limit was undefined, it would default to unlimited instead of zero.

This is critical because if a programmer forgets to explicitly set the limit for all plans, the gem would inadverntly grant unlimited resources to users. This also allows us to be more elegant and concise defining our plans (everything is blocked by default, so if we want a free tier / unsubscriber tier that doesn't give users anything, it's enough to define the plan without having to explicitly set to 0 each limit)

I asked Claude to draft a writeup of this breaking change:

# BREAKING CHANGE: Undefined Limits Default to Blocked (Secure by Default)

## Summary

This PR implements a **critical breaking change** to make undefined limits default to **0 (blocked)** instead of **`:unlimited` (fail-open)**. This aligns limit enforcement with feature gating philosophy: both are now **secure by default**, requiring explicit permission grants rather than implicitly allowing unlimited access.

**Status**: All 445 tests passing, 14 new comprehensive security tests added.

---

## The Trigger: Real-World Business Case

### User's Original Problem (myapp.com)

A production app (myapp) was discovered to have a critical security flaw in their pricing plan configuration:

```ruby
# myapp's intended configuration
config.plan :unsubscribed do
  name "Pending Subscription"
  description "Subscribe to a plan to get started"
  price 0
  hidden!
  default!
  # No limits defined - expected: block everything
  # Reality: unlimited access to everything! 😱
end
```

**Console output revealed the issue**:
```ruby
User.first.plan_limit_remaining(:projects)
# => :unlimited  # ❌ SECURITY ISSUE - Expected: 0

User.first.within_plan_limits?(:projects, by: 1)
# => true  # ❌ SECURITY ISSUE - Expected: false
```

**The Business Need**: For all-paid products (like myapp), unsubscribed users should have **zero access** without seeing an "Unsubscribed" plan cluttering the pricing page. The `hidden!` feature solves the visibility problem, but undefined limits inadvertently granted unlimited access.

**The Question**: "Is fail-open the right default for undefined limits?"

---

## Existing Behavior: Inconsistent Security Model

### Before This PR

The gem had **contradictory security defaults**:

| Type | Undefined Behavior | Security Model |
|------|-------------------|----------------|
| **Features** | `allows?(:undefined)` → `false` | ✅ **Fail-closed** (secure) |
| **Limits** | `plan_limit_remaining(:undefined)` → `:unlimited` | ❌ **Fail-open** (insecure) |

This inconsistency created **three critical problems**:

### 1. Security Risk: Forgotten Limits = Unlimited Access

```ruby
plan :premium do
  price 49
  limit :projects, to: 50
  limit :users, to: 10
  # Developer forgets to define :api_calls limit
end

# Result: UNLIMITED api_calls! 😱
org.plan_limit_remaining(:api_calls)
# => :unlimited  # Should be 0 (blocked)
```

### 2. Unexpected Behavior for Restrictive Plans

To create a restrictive plan that blocks everything except specific actions, developers had to explicitly define **every possible limit** as 0:

```ruby
# Before: Verbose and error-prone
plan :unsubscribed do
  price 0
  limit :projects, to: 0
  limit :api_calls, to: 0, per: :month
  limit :storage, to: 0
  limit :downloads, to: 0
  limit :exports, to: 0
  limit :users, to: 0
  # ... must define EVERY limit as 0
  # Miss one? Unlimited access!
end
```

### 3. Philosophical Inconsistency

**Why are features fail-closed but limits fail-open?**

Both represent "what users can do." The inconsistency was:
- Features: "Nothing allowed unless explicitly granted" ✅
- Limits: "Everything unlimited unless explicitly restricted" ❌

This violated the **Principle of Least Privilege** for limits while correctly implementing it for features.

---

## Why This Matters

### 1. Security by Default

**Fail-open = Security Vulnerability**

When systems default to permissive behavior, a single oversight (forgetting to define a limit) grants unintended access. This is particularly dangerous for:
- New limits added to the system (automatically unlimited on existing plans)
- Grandfathered/hidden plans (easy to miss when adding limits)
- Copy-paste errors in plan definitions

**Fail-closed = Secure by Design**

When systems default to restrictive behavior, oversights are immediately visible (users get blocked) and must be explicitly fixed. This forces intentionality.

### 2. Consistency Across the Gem

**Before**:
```ruby
# Features: explicit permission required
org.allows?(:api_access)         # => false (undefined)
org.allows?(:advanced_features)  # => false (undefined)

# Limits: implicitly unlimited (inconsistent!)
org.within_plan_limits?(:api_calls)  # => true (undefined = unlimited)
org.within_plan_limits?(:projects)   # => true (undefined = unlimited)
```

**After**:
```ruby
# Features: explicit permission required
org.plan_allows?(:api_access)         # => false (undefined)
org.plan_allows?(:advanced_features)  # => false (undefined)

# Limits: explicit permission required (consistent!)
org.within_plan_limits?(:api_calls)   # => false (undefined = 0)
org.within_plan_limits?(:projects)    # => false (undefined = 0)
```

### 3. Real-World Business Model Support

**All-Paid Products Pattern**:

Many SaaS products are fully paid with no free tier. For these products:
1. Unsubscribed users should have **zero access**
2. The "unsubscribed" plan shouldn't appear on pricing pages
3. Users should be immediately prompted to subscribe

**Before this PR**, achieving this required:
- Hidden plan (for visibility) ✅
- Explicitly defining every limit as 0 (for security) ❌ (verbose, error-prone)

**After this PR**, this works elegantly:
- Hidden plan (for visibility) ✅
- No limits defined (secure by default) ✅ (clean, safe)

```ruby
# After: Clean, secure, elegant
plan :unsubscribed do
  name "Pending Subscription"
  price 0
  hidden!
  default!
  # No limits needed - everything blocked by default! ✅
end
```

---


## The Solution: Implicit Safety vs Explicit Danger

### Philosophy: Secure by Default

**Core Principle**: Developers must **explicitly grant** access, not explicitly restrict it.

| Approach | Undefined Limit | To Grant Access |
|----------|----------------|-----------------|
| **Before (Explicit Restriction)** | `:unlimited` (dangerous default) | Do nothing (implicit) |
| | | OR define limit (explicit) |
| **After (Explicit Permission)** | `0` (safe default) | Add `unlimited :key` (explicit) |
| | | OR define `limit :key, to: N` (explicit) |

### Why Implicit Safety is More Elegant

**1. Fail-Closed Prevents Inadvertent Access**

```ruby
# Developer adds new limit :team_members to the app

# Before: Existing plans automatically get unlimited team_members! 😱
plan :basic do
  limit :projects, to: 5
  # :team_members undefined = :unlimited (oops!)
end

# After: Existing plans block team_members until explicitly defined ✅
plan :basic do
  limit :projects, to: 5
  # :team_members undefined = 0 (safe!)
  unlimited :team_members  # Must be explicit
end
```

**2. Restrictive Plans Are Clean**

```ruby
# Before: Must define every limit as 0 (verbose)
plan :unsubscribed do
  price 0
  limit :projects, to: 0
  limit :api_calls, to: 0, per: :month
  limit :storage, to: 0
  limit :downloads, to: 0
  limit :exports, to: 0
  # ... 20 more lines
end

# After: Undefined = blocked (elegant)
plan :unsubscribed do
  price 0
  hidden!
  default!
  # Everything blocked by default ✅
end
```

**3. Permissive Plans Are Explicit**

```ruby
# Before: Undefined = unlimited (implicit permission)
plan :enterprise do
  price 999
  # :projects undefined = :unlimited (hidden permission)
end

# After: Must be explicit
plan :enterprise do
  price 999
  unlimited :projects  # Clear, intentional, auditable
end
```

**4. Avoids Inadvertently Granting Unlimited Access**

The most dangerous bugs are silent ones. When a limit is forgotten:

**Before**: App works, users get unlimited access, problem discovered in production (if ever)

**After**: App immediately blocks users, problem discovered in development, forces fix

---

## Breaking Changes

### Who Is Affected?

Apps that rely on undefined limits being unlimited will break. Specifically:

**1. Plans with missing limit definitions**:
```ruby
plan :basic do
  limit :projects, to: 5
  # :api_calls was undefined, now blocked
end
```

**2. Hidden/grandfathered plans without full limit definitions**:
```ruby
plan :legacy_2020 do
  hidden!
  limit :projects, to: 100
  # Other limits undefined, now blocked
end
```

**3. Default plans without limit definitions**:
```ruby
plan :free do
  default!
  # Expected everything unlimited, now everything blocked
end
```

### Migration Guide

**For apps that want to preserve unlimited behavior on undefined limits**:

```ruby
# Before (implicit unlimited)
plan :enterprise do
  limit :projects, to: 1000
  # :storage was undefined = :unlimited
end

# After (explicit unlimited)
plan :enterprise do
  limit :projects, to: 1000
  unlimited :storage  # Make it explicit
end
```

**For apps that want everything blocked (like myapp)**:

```ruby
# Before (had to define everything as 0)
plan :unsubscribed do
  limit :projects, to: 0
  limit :api_calls, to: 0, per: :month
  limit :storage, to: 0
  # ... many more
end

# After (undefined = blocked automatically)
plan :unsubscribed do
  hidden!
  default!
  # No limits needed - everything blocked! ✅
end
```

**For apps adding new limits to existing plans**:

```ruby
# When adding a new limit :team_members to your app:

# Step 1: Add to plans that should allow it
plan :premium do
  limit :projects, to: 100
  limit :team_members, to: 10  # NEW
end

plan :enterprise do
  unlimited :projects
  unlimited :team_members  # NEW
end

# Step 2: Other plans automatically block it (secure!)
plan :basic do
  limit :projects, to: 5
  # :team_members undefined = 0 (blocked) ✅
end
```

## Conclusion

This breaking change:

✅ **Fixes a real security issue** (myapp prod uction bug)
✅ **Aligns philosophy** (consistent fail-closed behavior)
✅ **Improves developer experience** (less boilerplate for common case)
✅ **Future-proofs the gem** (new limits secure by default)
✅ **Makes unlimited explicit** (self-documenting, auditable)
✅ **Is well-tested** (14 comprehensive tests, 445 total passing)
✅ **Has clear migration path** (add `unlimited :key` where needed)

The gem is at v0.1.2 with limited adoption - **now is the right time** to make this breaking change before v1.0. The alternative (keeping insecure defaults) would:

❌ Require verbose workarounds for common use cases
❌ Create ongoing security risks from forgotten limits
❌ Maintain philosophical inconsistency with features
❌ Force a more disruptive change later

**This is the right default.**