### PR TITLE
Expose pricing plan resolution and provenance helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.3.3] - 2026-03-19
+
+- **Add plan provenance helpers**: `current_pricing_plan_resolution`, `current_pricing_plan_source`, and `PlanResolver.resolution_for(plan_owner)` now expose whether the effective plan comes from a manual assignment, a Pay subscription, or the default plan
+- **Preserve underlying billing context**: resolution objects include the current subscription when present, even when a manual assignment overrides it for entitlements
+- **Clarify effective plan vs billing state**: docs now explicitly distinguish the effective pricing plan from Pay/Stripe subscription status
+
 ## [0.3.2] - 2026-02-25
 
 - **Fix stale grace warnings after plan upgrades**: Grace/blocked flags now auto-clear when usage drops below limit (self-healing state)

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ The `pricing_plans` gem needs three new models in the schema in order to work: `
 - `PricingPlans::Assignment` allow manual plan overrides independent of billing system (or before you wire up Stripe/Pay). Great for admin toggles, trials, demos.
   - What: The arbitrary `plan_key` and a `source` label (default "manual"). Unique per plan_owner.
   - How it's used: `PlanResolver` checks manual assignment → Pay → default plan. Manual assignments (admin overrides) take precedence over subscription-based plans. You can call `assign_pricing_plan!` and `remove_pricing_plan!` on the plan_owner.
+  - Provenance helpers: `current_pricing_plan_source` tells you whether the effective plan came from `:assignment`, `:subscription`, or `:default`, and `current_pricing_plan_resolution` exposes the assignment and current subscription objects when you need both entitlement and billing context.
 
 - `PricingPlans::EnforcementState` tracks per-plan_owner per-limit enforcement state for persistent caps and per-period allowances (grace/warnings/block state) in a race-safe way.
   - What: `exceeded_at`, `blocked_at`, last warning info, and a small JSON `data` column where we persist plan-derived parameters like grace period seconds.

--- a/docs/03-model-helpers.md
+++ b/docs/03-model-helpers.md
@@ -301,6 +301,8 @@ user.assign_pricing_plan!(:pro)              # manual assignment override
 user.remove_pricing_plan!                    # remove manual override (fallback to default)
 ```
 
+If you need both the plan and its provenance, prefer calling `current_pricing_plan_resolution` once and reading both values from that object.
+
 If you need the full provenance, use the resolution object:
 
 ```ruby

--- a/docs/03-model-helpers.md
+++ b/docs/03-model-helpers.md
@@ -301,7 +301,7 @@ user.assign_pricing_plan!(:pro)              # manual assignment override
 user.remove_pricing_plan!                    # remove manual override (fallback to default)
 ```
 
-If you need both the plan and its provenance, prefer calling `current_pricing_plan_resolution` once and reading both values from that object.
+**Performance note:** Each call to `current_pricing_plan`, `current_pricing_plan_source`, or `current_pricing_plan_resolution` performs a fresh database lookup. If you need both the plan and its provenance, call `current_pricing_plan_resolution` once and read both values from that object — this avoids duplicate queries.
 
 If you need the full provenance, use the resolution object:
 
@@ -316,6 +316,8 @@ resolution.subscription                      # => Pay subscription | nil
 ```
 
 This distinction matters: the **effective pricing plan** is what controls entitlements and limits inside your app. The **Pay/Stripe subscription state** is billing-facing. A manual assignment may intentionally override the subscription-backed plan while still leaving the underlying subscription present for billing operations.
+
+**Edge case:** `source` can be `:default` even when `subscription` is non-nil. This happens when a Pay subscription exists but its `processor_plan` (Stripe price ID) doesn't map to any plan in your registry. The subscription is preserved for billing context, but the effective plan falls back to your configured default.
 
 `resolution.to_h` is handy for inspection and tests, but it preserves the raw `plan`, `assignment`, and `subscription` objects. If you need a JSON-safe payload, build one explicitly from the scalar fields you care about.
 

--- a/docs/03-model-helpers.md
+++ b/docs/03-model-helpers.md
@@ -317,6 +317,8 @@ resolution.subscription                      # => Pay subscription | nil
 
 This distinction matters: the **effective pricing plan** is what controls entitlements and limits inside your app. The **Pay/Stripe subscription state** is billing-facing. A manual assignment may intentionally override the subscription-backed plan while still leaving the underlying subscription present for billing operations.
 
+`resolution.to_h` is handy for inspection and tests, but it preserves the raw `plan`, `assignment`, and `subscription` objects. If you need a JSON-safe payload, build one explicitly from the scalar fields you care about.
+
 ### Misc
 
 ```ruby

--- a/docs/03-model-helpers.md
+++ b/docs/03-model-helpers.md
@@ -295,9 +295,25 @@ You can also use the top-level equivalents if you prefer: `PricingPlans.severity
 You can also check and override the current pricing plan for any user, which comes handy as an admin:
 ```ruby
 user.current_pricing_plan                    # => PricingPlans::Plan
+user.current_pricing_plan_source             # => :assignment, :subscription, :default
+user.current_pricing_plan_resolution         # => PricingPlans::PlanResolution
 user.assign_pricing_plan!(:pro)              # manual assignment override
 user.remove_pricing_plan!                    # remove manual override (fallback to default)
 ```
+
+If you need the full provenance, use the resolution object:
+
+```ruby
+resolution = user.current_pricing_plan_resolution
+
+resolution.plan.key                          # => :enterprise
+resolution.source                            # => :assignment
+resolution.assignment                        # => PricingPlans::Assignment | nil
+resolution.assignment_source                 # => "admin" | "manual" | nil
+resolution.subscription                      # => Pay subscription | nil
+```
+
+This distinction matters: the **effective pricing plan** is what controls entitlements and limits inside your app. The **Pay/Stripe subscription state** is billing-facing. A manual assignment may intentionally override the subscription-backed plan while still leaving the underlying subscription present for billing operations.
 
 ### Misc
 
@@ -311,7 +327,8 @@ And finally, you get very thin convenient wrappers if you're using the `pay` gem
 ```ruby
 # Pay (Stripe) convenience (returns false/nil when Pay is absent)
 # Note: this is billing-facing state, distinct from our in-app
-# enforcement grace which is tracked per-limit.
+# enforcement grace which is tracked per-limit, and distinct from
+# the effective plan resolved by current_pricing_plan.
 user.pay_subscription_active?                # => true/false
 user.pay_on_trial?                           # => true/false
 user.pay_on_grace_period?                    # => true/false

--- a/lib/pricing_plans.rb
+++ b/lib/pricing_plans.rb
@@ -21,6 +21,7 @@ module PricingPlans
   autoload :Configuration, "pricing_plans/configuration"
   autoload :Registry, "pricing_plans/registry"
   autoload :Plan, "pricing_plans/plan"
+  autoload :PlanResolution, "pricing_plans/plan_resolution"
   autoload :DSL, "pricing_plans/dsl"
   autoload :IntegerRefinements, "pricing_plans/integer_refinements"
   autoload :PlanResolver, "pricing_plans/plan_resolver"

--- a/lib/pricing_plans/pay_support.rb
+++ b/lib/pricing_plans/pay_support.rb
@@ -15,7 +15,8 @@ module PricingPlans
     def subscription_active_for?(plan_owner)
       return false unless plan_owner
 
-      log_debug "[PricingPlans::PaySupport] subscription_active_for? called for #{plan_owner.class.name}##{plan_owner.id}"
+      owner_id = plan_owner.respond_to?(:id) ? plan_owner.id : "N/A"
+      log_debug "[PricingPlans::PaySupport] subscription_active_for? called for #{plan_owner.class.name}##{owner_id}"
 
       # Prefer Pay's official API on the payment_processor
       if plan_owner.respond_to?(:payment_processor) && (pp = plan_owner.payment_processor)

--- a/lib/pricing_plans/pay_support.rb
+++ b/lib/pricing_plans/pay_support.rb
@@ -66,7 +66,8 @@ module PricingPlans
     def current_subscription_for(plan_owner)
       return nil unless pay_available?
 
-      log_debug "[PricingPlans::PaySupport] current_subscription_for called for #{plan_owner.class.name}##{plan_owner.id}"
+      owner_id = plan_owner.respond_to?(:id) ? plan_owner.id : "N/A"
+      log_debug "[PricingPlans::PaySupport] current_subscription_for called for #{plan_owner.class.name}##{owner_id}"
 
       # Prefer Pay's payment_processor API
       if plan_owner.respond_to?(:payment_processor) && (pp = plan_owner.payment_processor)

--- a/lib/pricing_plans/plan_owner.rb
+++ b/lib/pricing_plans/plan_owner.rb
@@ -198,6 +198,14 @@ module PricingPlans
       PlanResolver.effective_plan_for(self)
     end
 
+    def current_pricing_plan_resolution
+      PlanResolver.resolution_for(self)
+    end
+
+    def current_pricing_plan_source
+      current_pricing_plan_resolution.source
+    end
+
     def on_free_plan?
       plan = current_pricing_plan || PricingPlans::Registry.default_plan
       plan&.free? || false

--- a/lib/pricing_plans/plan_resolution.rb
+++ b/lib/pricing_plans/plan_resolution.rb
@@ -32,6 +32,7 @@ module PricingPlans
       assignment&.source
     end
 
+    # Extends Struct#to_h with derived fields commonly useful in serialization.
     def to_h
       {
         plan: plan,

--- a/lib/pricing_plans/plan_resolution.rb
+++ b/lib/pricing_plans/plan_resolution.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module PricingPlans
+  class PlanResolution < Struct.new(:plan, :source, :assignment, :subscription, keyword_init: true)
+    SOURCES = [:assignment, :subscription, :default].freeze
+
+    def initialize(**attributes)
+      super
+
+      unless SOURCES.include?(source)
+        raise ArgumentError, "Invalid source: #{source.inspect}. Must be one of: #{SOURCES.inspect}"
+      end
+    end
+
+    def assignment?
+      source == :assignment
+    end
+
+    def subscription?
+      source == :subscription
+    end
+
+    def default?
+      source == :default
+    end
+
+    def plan_key
+      plan&.key
+    end
+
+    def assignment_source
+      assignment&.source
+    end
+
+    def to_h
+      {
+        plan: plan,
+        plan_key: plan_key,
+        source: source,
+        assignment: assignment,
+        assignment_source: assignment_source,
+        subscription: subscription
+      }
+    end
+  end
+end

--- a/lib/pricing_plans/plan_resolution.rb
+++ b/lib/pricing_plans/plan_resolution.rb
@@ -34,7 +34,8 @@ module PricingPlans
       assignment&.source
     end
 
-    # Extends Struct#to_h with derived fields commonly useful in serialization.
+    # Extends Struct#to_h with derived fields.
+    # Note: this preserves the raw plan / assignment / subscription objects.
     def to_h
       super.merge(
         plan_key: plan_key,

--- a/lib/pricing_plans/plan_resolution.rb
+++ b/lib/pricing_plans/plan_resolution.rb
@@ -10,6 +10,8 @@ module PricingPlans
       unless SOURCES.include?(source)
         raise ArgumentError, "Invalid source: #{source.inspect}. Must be one of: #{SOURCES.inspect}"
       end
+
+      freeze
     end
 
     def assignment?
@@ -34,14 +36,10 @@ module PricingPlans
 
     # Extends Struct#to_h with derived fields commonly useful in serialization.
     def to_h
-      {
-        plan: plan,
+      super.merge(
         plan_key: plan_key,
-        source: source,
-        assignment: assignment,
-        assignment_source: assignment_source,
-        subscription: subscription
-      }
+        assignment_source: assignment_source
+      )
     end
   end
 end

--- a/lib/pricing_plans/plan_resolver.rb
+++ b/lib/pricing_plans/plan_resolver.rb
@@ -94,7 +94,6 @@ module PricingPlans
 
         pay_available = pay_available?
         log_debug "[PricingPlans::PlanResolver] PaySupport.pay_available? = #{pay_available}"
-        log_debug "[PricingPlans::PlanResolver] defined?(Pay) = #{defined?(Pay)}"
 
         return nil unless pay_available
 

--- a/lib/pricing_plans/plan_resolver.rb
+++ b/lib/pricing_plans/plan_resolver.rb
@@ -8,43 +8,52 @@ module PricingPlans
       end
 
       def effective_plan_for(plan_owner)
-        log_debug "[PricingPlans::PlanResolver] effective_plan_for called for #{plan_owner.class.name}##{plan_owner.respond_to?(:id) ? plan_owner.id : 'N/A'}"
-
-        # 1. Check manual assignment FIRST (admin overrides take precedence)
-        log_debug "[PricingPlans::PlanResolver] Checking for manual assignment..."
-        if plan_owner.respond_to?(:id)
-          assignment = Assignment.find_by(
-            plan_owner_type: plan_owner.class.name,
-            plan_owner_id: plan_owner.id
-          )
-          if assignment
-            log_debug "[PricingPlans::PlanResolver] Found manual assignment: #{assignment.plan_key}"
-            return Registry.plan(assignment.plan_key)
-          else
-            log_debug "[PricingPlans::PlanResolver] No manual assignment found"
-          end
-        end
-
-        # 2. Check Pay subscription status
-        pay_available = PaySupport.pay_available?
-        log_debug "[PricingPlans::PlanResolver] PaySupport.pay_available? = #{pay_available}"
-        log_debug "[PricingPlans::PlanResolver] defined?(Pay) = #{defined?(Pay)}"
-
-        if pay_available
-          log_debug "[PricingPlans::PlanResolver] Calling resolve_plan_from_pay..."
-          plan_from_pay = resolve_plan_from_pay(plan_owner)
-          log_debug "[PricingPlans::PlanResolver] resolve_plan_from_pay returned: #{plan_from_pay ? plan_from_pay.key : 'nil'}"
-          return plan_from_pay if plan_from_pay
-        end
-
-        # 3. Fall back to default plan
-        default = Registry.default_plan
-        log_debug "[PricingPlans::PlanResolver] Returning default plan: #{default ? default.key : 'nil'}"
-        default
+        resolution_for(plan_owner).plan
       end
 
       def plan_key_for(plan_owner)
-        effective_plan_for(plan_owner)&.key
+        resolution_for(plan_owner).plan_key
+      end
+
+      def resolution_for(plan_owner)
+        log_debug "[PricingPlans::PlanResolver] resolution_for called for #{plan_owner.class.name}##{plan_owner.respond_to?(:id) ? plan_owner.id : 'N/A'}"
+
+        assignment = assignment_for(plan_owner)
+        subscription = current_subscription_for(plan_owner)
+
+        if assignment
+          log_debug "[PricingPlans::PlanResolver] Returning assignment-backed resolution: #{assignment.plan_key}"
+          return PlanResolution.new(
+            plan: Registry.plan(assignment.plan_key),
+            source: :assignment,
+            assignment: assignment,
+            subscription: subscription
+          )
+        end
+
+        if subscription
+          processor_plan = subscription.processor_plan
+          log_debug "[PricingPlans::PlanResolver] resolution_for subscription processor_plan = #{processor_plan.inspect}"
+
+          if processor_plan && (plan = plan_from_processor_plan(processor_plan))
+            log_debug "[PricingPlans::PlanResolver] Returning subscription-backed resolution: #{plan.key}"
+            return PlanResolution.new(
+              plan: plan,
+              source: :subscription,
+              assignment: nil,
+              subscription: subscription
+            )
+          end
+        end
+
+        default = Registry.default_plan
+        log_debug "[PricingPlans::PlanResolver] Returning default-backed resolution: #{default ? default.key : 'nil'}"
+        PlanResolution.new(
+          plan: default,
+          source: :default,
+          assignment: nil,
+          subscription: subscription
+        )
       end
 
       def assign_plan_manually!(plan_owner, plan_key, source: "manual")
@@ -62,46 +71,36 @@ module PricingPlans
         PaySupport.pay_available?
       end
 
-      def resolve_plan_from_pay(plan_owner)
-        log_debug "[PricingPlans::PlanResolver] resolve_plan_from_pay: checking if plan_owner has payment_processor or Pay methods..."
+      def assignment_for(plan_owner)
+        log_debug "[PricingPlans::PlanResolver] Checking for manual assignment..."
+        return nil unless plan_owner.respond_to?(:id)
 
-        # Check if plan_owner has payment_processor (preferred) or Pay methods directly (fallback)
-        has_payment_processor = plan_owner.respond_to?(:payment_processor)
-        has_pay_methods = plan_owner.respond_to?(:subscribed?) ||
-                          plan_owner.respond_to?(:on_trial?) ||
-                          plan_owner.respond_to?(:on_grace_period?) ||
-                          plan_owner.respond_to?(:subscriptions)
+        assignment = Assignment.find_by(
+          plan_owner_type: plan_owner.class.name,
+          plan_owner_id: plan_owner.id
+        )
 
-        log_debug "[PricingPlans::PlanResolver] has_payment_processor? #{has_payment_processor}"
-        log_debug "[PricingPlans::PlanResolver] has_pay_methods? #{has_pay_methods}"
-
-        # PaySupport will handle both payment_processor and direct Pay methods
-        return nil unless has_payment_processor || has_pay_methods
-
-        # Check if plan_owner has active subscription, trial, or grace period
-        log_debug "[PricingPlans::PlanResolver] Calling PaySupport.subscription_active_for?..."
-        is_active = PaySupport.subscription_active_for?(plan_owner)
-        log_debug "[PricingPlans::PlanResolver] subscription_active_for? returned: #{is_active}"
-
-        if is_active
-          log_debug "[PricingPlans::PlanResolver] Calling PaySupport.current_subscription_for..."
-          subscription = PaySupport.current_subscription_for(plan_owner)
-          log_debug "[PricingPlans::PlanResolver] current_subscription_for returned: #{subscription ? subscription.class.name : 'nil'}"
-          return nil unless subscription
-
-          # Map processor plan to our plan
-          processor_plan = subscription.processor_plan
-          log_debug "[PricingPlans::PlanResolver] subscription.processor_plan = #{processor_plan.inspect}"
-
-          if processor_plan
-            matched_plan = plan_from_processor_plan(processor_plan)
-            log_debug "[PricingPlans::PlanResolver] plan_from_processor_plan returned: #{matched_plan ? matched_plan.key : 'nil'}"
-            return matched_plan
-          end
+        if assignment
+          log_debug "[PricingPlans::PlanResolver] Found manual assignment: #{assignment.plan_key}"
+        else
+          log_debug "[PricingPlans::PlanResolver] No manual assignment found"
         end
 
-        log_debug "[PricingPlans::PlanResolver] resolve_plan_from_pay returning nil"
-        nil
+        assignment
+      end
+
+      def current_subscription_for(plan_owner)
+        return nil unless plan_owner
+
+        pay_available = pay_available?
+        log_debug "[PricingPlans::PlanResolver] PaySupport.pay_available? = #{pay_available}"
+        log_debug "[PricingPlans::PlanResolver] defined?(Pay) = #{defined?(Pay)}"
+
+        return nil unless pay_available
+
+        subscription = PaySupport.current_subscription_for(plan_owner)
+        log_debug "[PricingPlans::PlanResolver] current_subscription_for returned: #{subscription ? subscription.class.name : 'nil'}"
+        subscription
       end
 
       def plan_from_processor_plan(processor_plan)

--- a/lib/pricing_plans/plan_resolver.rb
+++ b/lib/pricing_plans/plan_resolver.rb
@@ -97,6 +97,9 @@ module PricingPlans
 
         return nil unless pay_available
 
+        # This intentionally delegates the active/trial/grace filtering contract
+        # to PaySupport.current_subscription_for so resolution_for can preserve
+        # the same billing context wherever it is called.
         subscription = PaySupport.current_subscription_for(plan_owner)
         log_debug "[PricingPlans::PlanResolver] current_subscription_for returned: #{subscription ? subscription.class.name : 'nil'}"
         subscription

--- a/lib/pricing_plans/version.rb
+++ b/lib/pricing_plans/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PricingPlans
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/test/pay_support_test.rb
+++ b/test/pay_support_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PaySupportTest < ActiveSupport::TestCase
+  def test_subscription_active_for_handles_objects_without_id
+    assert_equal false, PricingPlans::PaySupport.subscription_active_for?(Object.new)
+  end
+
+  def test_current_subscription_for_handles_objects_without_id
+    assert_nil PricingPlans::PaySupport.current_subscription_for(Object.new)
+  end
+end

--- a/test/plan_owner_helpers_test.rb
+++ b/test/plan_owner_helpers_test.rb
@@ -11,6 +11,10 @@ class PlanOwnerHelpersTest < ActiveSupport::TestCase
       config.plan :free do
         limits :projects, to: 1
       end
+      config.plan :pro do
+        stripe_price "price_pro_123"
+        allows :api_access
+      end
     end
     # Re-register counters after reset
     Project.send(:limited_by_pricing_plans, :projects, plan_owner: :organization) if Project.respond_to?(:limited_by_pricing_plans)
@@ -23,6 +27,8 @@ class PlanOwnerHelpersTest < ActiveSupport::TestCase
     assert_respond_to org, :plan_limit_remaining
     assert_respond_to org, :plan_limit_percent_used
     assert_respond_to org, :current_pricing_plan
+    assert_respond_to org, :current_pricing_plan_resolution
+    assert_respond_to org, :current_pricing_plan_source
     assert_respond_to org, :assign_pricing_plan!
     assert_respond_to org, :remove_pricing_plan!
     assert_respond_to org, :plan_allows?
@@ -37,6 +43,42 @@ class PlanOwnerHelpersTest < ActiveSupport::TestCase
 
     # Smoke check a real call path
     assert_equal :free, org.current_pricing_plan.key
+  end
+
+  def test_current_pricing_plan_resolution_for_default_plan
+    org = create_organization
+
+    resolution = org.current_pricing_plan_resolution
+
+    assert_equal :free, resolution.plan_key
+    assert_equal :default, org.current_pricing_plan_source
+    assert resolution.default?
+  end
+
+  def test_current_pricing_plan_resolution_for_manual_assignment
+    org = create_organization
+
+    org.assign_pricing_plan!(:pro, source: "admin")
+
+    resolution = org.current_pricing_plan_resolution
+
+    assert_equal :pro, resolution.plan_key
+    assert_equal :assignment, org.current_pricing_plan_source
+    assert_equal "admin", resolution.assignment_source
+    assert resolution.assignment?
+  end
+
+  def test_current_pricing_plan_resolution_for_subscription
+    org = create_organization(
+      pay_subscription: { active: true, processor_plan: "price_pro_123" }
+    )
+
+    resolution = org.current_pricing_plan_resolution
+
+    assert_equal :pro, resolution.plan_key
+    assert_equal :subscription, org.current_pricing_plan_source
+    assert_equal "price_pro_123", resolution.subscription.processor_plan
+    assert resolution.subscription?
   end
 
   def test_englishy_sugar_methods_defined_from_associations
@@ -66,12 +108,7 @@ class PlanOwnerHelpersTest < ActiveSupport::TestCase
     # Default plan does not allow :api_access
     refute org.plan_allows_api_access?
 
-    # Add a pro plan that allows the feature and assign it
-    PricingPlans.configure do |config|
-      config.plan :pro do
-        allows :api_access
-      end
-    end
+    # Assign the preconfigured pro plan, which allows :api_access
     PricingPlans::Assignment.assign_plan_to(org, :pro)
     assert org.plan_allows_api_access?
     assert_equal org.plan_allows?(:api_access), org.plan_allows_api_access?

--- a/test/plan_resolution_test.rb
+++ b/test/plan_resolution_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PlanResolutionTest < ActiveSupport::TestCase
+  def test_plan_resolution_is_frozen
+    resolution = PricingPlans::PlanResolution.new(
+      plan: OpenStruct.new(key: :pro),
+      source: :subscription,
+      assignment: nil,
+      subscription: OpenStruct.new(processor_plan: "price_pro_123")
+    )
+
+    assert resolution.frozen?
+    assert_raises(FrozenError) { resolution.source = :default }
+  end
+
+  def test_plan_resolution_to_h_includes_struct_and_derived_fields
+    assignment = OpenStruct.new(source: "admin")
+    subscription = OpenStruct.new(processor_plan: "price_pro_123")
+
+    resolution = PricingPlans::PlanResolution.new(
+      plan: OpenStruct.new(key: :enterprise),
+      source: :assignment,
+      assignment: assignment,
+      subscription: subscription
+    )
+
+    assert_equal(
+      {
+        plan: resolution.plan,
+        source: :assignment,
+        assignment: assignment,
+        subscription: subscription,
+        plan_key: :enterprise,
+        assignment_source: "admin"
+      },
+      resolution.to_h
+    )
+  end
+end

--- a/test/plan_resolution_test.rb
+++ b/test/plan_resolution_test.rb
@@ -3,12 +3,16 @@
 require "test_helper"
 
 class PlanResolutionTest < ActiveSupport::TestCase
+  PlanStub = Struct.new(:key, keyword_init: true)
+  AssignmentStub = Struct.new(:source, keyword_init: true)
+  SubscriptionStub = Struct.new(:processor_plan, keyword_init: true)
+
   def test_plan_resolution_is_frozen
     resolution = PricingPlans::PlanResolution.new(
-      plan: OpenStruct.new(key: :pro),
+      plan: PlanStub.new(key: :pro),
       source: :subscription,
       assignment: nil,
-      subscription: OpenStruct.new(processor_plan: "price_pro_123")
+      subscription: SubscriptionStub.new(processor_plan: "price_pro_123")
     )
 
     assert resolution.frozen?
@@ -16,11 +20,11 @@ class PlanResolutionTest < ActiveSupport::TestCase
   end
 
   def test_plan_resolution_to_h_includes_struct_and_derived_fields
-    assignment = OpenStruct.new(source: "admin")
-    subscription = OpenStruct.new(processor_plan: "price_pro_123")
+    assignment = AssignmentStub.new(source: "admin")
+    subscription = SubscriptionStub.new(processor_plan: "price_pro_123")
 
     resolution = PricingPlans::PlanResolution.new(
-      plan: OpenStruct.new(key: :enterprise),
+      plan: PlanStub.new(key: :enterprise),
       source: :assignment,
       assignment: assignment,
       subscription: subscription

--- a/test/services/plan_resolver_payment_processor_test.rb
+++ b/test/services/plan_resolver_payment_processor_test.rb
@@ -67,6 +67,20 @@ class PlanResolverPaymentProcessorTest < ActiveSupport::TestCase
     assert_equal :pro, plan.key, "Should detect subscription regardless of its name"
   end
 
+  def test_resolution_for_exposes_payment_processor_subscription
+    user = create_user_with_payment_processor(
+      subscription_name: "pro",
+      processor_plan: "price_pro_monthly",
+      active: true
+    )
+
+    resolution = PricingPlans::PlanResolver.resolution_for(user)
+
+    assert_equal :pro, resolution.plan_key
+    assert_equal :subscription, resolution.source
+    assert_equal "price_pro_monthly", resolution.subscription.processor_plan
+  end
+
   def test_finds_active_subscription_among_multiple
     # Users often have multiple subscriptions (old canceled ones + current active)
     # The fix ensures we iterate through ALL subscriptions to find the active one

--- a/test/services/plan_resolver_payment_processor_test.rb
+++ b/test/services/plan_resolver_payment_processor_test.rb
@@ -81,6 +81,20 @@ class PlanResolverPaymentProcessorTest < ActiveSupport::TestCase
     assert_equal "price_pro_monthly", resolution.subscription.processor_plan
   end
 
+  def test_inactive_payment_processor_subscription_falls_back_to_default
+    user = create_user_with_payment_processor(
+      subscription_name: "pro",
+      processor_plan: "price_pro_monthly",
+      active: false
+    )
+
+    resolution = PricingPlans::PlanResolver.resolution_for(user)
+
+    assert_equal :free, resolution.plan_key
+    assert_equal :default, resolution.source
+    assert_nil resolution.subscription
+  end
+
   def test_finds_active_subscription_among_multiple
     # Users often have multiple subscriptions (old canceled ones + current active)
     # The fix ensures we iterate through ALL subscriptions to find the active one

--- a/test/services/plan_resolver_test.rb
+++ b/test/services/plan_resolver_test.rb
@@ -3,6 +3,80 @@
 require "test_helper"
 
 class PlanResolverTest < ActiveSupport::TestCase
+  def test_resolution_for_manual_assignment_includes_provenance
+    org = create_organization
+
+    assignment = PricingPlans::Assignment.assign_plan_to(org, :enterprise, source: "admin")
+
+    resolution = PricingPlans::PlanResolver.resolution_for(org)
+
+    assert_equal :enterprise, resolution.plan_key
+    assert_equal :assignment, resolution.source
+    assert_equal assignment, resolution.assignment
+    assert_nil resolution.subscription
+    assert resolution.assignment?
+    refute resolution.subscription?
+    refute resolution.default?
+    assert_equal "admin", resolution.assignment_source
+  end
+
+  def test_resolution_for_subscription_includes_subscription_object
+    org = create_organization(
+      pay_subscription: { active: true, processor_plan: "price_pro_123" }
+    )
+
+    resolution = PricingPlans::PlanResolver.resolution_for(org)
+
+    assert_equal :pro, resolution.plan_key
+    assert_equal :subscription, resolution.source
+    assert_nil resolution.assignment
+    assert_equal "price_pro_123", resolution.subscription.processor_plan
+    refute resolution.assignment?
+    assert resolution.subscription?
+    refute resolution.default?
+  end
+
+  def test_resolution_for_default_plan_keeps_default_source
+    org = create_organization
+
+    resolution = PricingPlans::PlanResolver.resolution_for(org)
+
+    assert_equal :free, resolution.plan_key
+    assert_equal :default, resolution.source
+    assert_nil resolution.assignment
+    assert_nil resolution.subscription
+    refute resolution.assignment?
+    refute resolution.subscription?
+    assert resolution.default?
+  end
+
+  def test_resolution_for_manual_assignment_keeps_underlying_subscription
+    org = create_organization(
+      pay_subscription: { active: true, processor_plan: "price_pro_123" }
+    )
+
+    PricingPlans::Assignment.assign_plan_to(org, :enterprise, source: "admin")
+
+    resolution = PricingPlans::PlanResolver.resolution_for(org)
+
+    assert_equal :enterprise, resolution.plan_key
+    assert_equal :assignment, resolution.source
+    assert_equal "admin", resolution.assignment_source
+    assert_equal "price_pro_123", resolution.subscription.processor_plan
+  end
+
+  def test_resolution_for_unknown_subscription_plan_falls_back_to_default_but_keeps_subscription
+    org = create_organization(
+      pay_subscription: { active: true, processor_plan: "price_unknown_999" }
+    )
+
+    resolution = PricingPlans::PlanResolver.resolution_for(org)
+
+    assert_equal :free, resolution.plan_key
+    assert_equal :default, resolution.source
+    assert_equal "price_unknown_999", resolution.subscription.processor_plan
+  end
+
   def test_effective_plan_with_active_subscription
     org = create_organization(
       pay_subscription: { active: true, processor_plan: "price_pro_123" }

--- a/test/services/plan_resolver_test.rb
+++ b/test/services/plan_resolver_test.rb
@@ -163,6 +163,18 @@ class PlanResolverTest < ActiveSupport::TestCase
     assert_equal :enterprise, plan.key
   end
 
+  def test_inactive_subscription_falls_back_to_default_resolution
+    org = create_organization(
+      pay_subscription: { active: false, processor_plan: "price_pro_123" }
+    )
+
+    resolution = PricingPlans::PlanResolver.resolution_for(org)
+
+    assert_equal :free, resolution.plan_key
+    assert_equal :default, resolution.source
+    assert_nil resolution.subscription
+  end
+
   def test_plan_key_for_convenience_method
     org = create_organization(
       pay_subscription: { active: true, processor_plan: "price_pro_123" }


### PR DESCRIPTION
## Summary
- add `PricingPlans::PlanResolution` as the canonical result of plan resolution
- expose `current_pricing_plan_resolution` and `current_pricing_plan_source` on plan owners
- preserve underlying Stripe subscription context even when a manual assignment wins
- refactor `PlanResolver` to derive effective plan selection from a single resolution path
- document and test that effective plan access is separate from billing subscription state

## Testing
- `bundle exec rake test`