### PR TITLE
Never 500 a pricing page when Stripe is unreachable

### DIFF
--- a/lib/pricing_plans/plan.rb
+++ b/lib/pricing_plans/plan.rb
@@ -445,9 +445,13 @@ module PricingPlans
     def currency_symbol
       if stripe_price
         # Try to derive from Stripe API/cache; fall back to default
-        pr = fetch_stripe_price_record(preferred_price_id(:month) || preferred_price_id(:year))
-        if pr
-          return currency_symbol_from(pr)
+        begin
+          pr = fetch_stripe_price_record(preferred_price_id(:month) || preferred_price_id(:year))
+          if pr
+            return currency_symbol_from(pr)
+          end
+        rescue StandardError
+          # Stripe unreachable, rate-limited or unconfigured: never take down a pricing page
         end
       end
       PricingPlans.configuration.default_currency_symbol

--- a/test/price_components_test.rb
+++ b/test/price_components_test.rb
@@ -114,6 +114,28 @@ class PriceComponentsTest < ActiveSupport::TestCase
     end
   end
 
+  def with_raising_stripe_stub
+    stripe_mod = Module.new
+    price_class = Class.new do
+      def self.retrieve(_id)
+        raise StandardError, "No API key provided"
+      end
+    end
+    stripe_mod.const_set(:Price, price_class)
+    Object.const_set(:Stripe, stripe_mod)
+    yield
+  ensure
+    Object.send(:remove_const, :Stripe) if defined?(Stripe)
+  end
+
+  def test_currency_symbol_falls_back_when_stripe_lookup_raises
+    configure_with_stripe_ids
+    plan = PricingPlans::Registry.plan(:pro)
+    with_raising_stripe_stub do
+      assert_equal PricingPlans.configuration.default_currency_symbol, plan.currency_symbol
+    end
+  end
+
   class MemoryCache
     attr_reader :writes
     def initialize


### PR DESCRIPTION
## The defect

`PricingPlans::Plan#currency_symbol` calls Stripe without a rescue. When Stripe is unreachable, rate-limiting, or simply has no API key configured, rendering a pricing page raises and the whole page 500s.

Observed downstream, on `pricing_plans` 0.4.0, rendering a stock pricing plan card:

```
Stripe::APIRequestor#check_api_key!
Stripe::APIResource.retrieve
pricing_plans-0.4.0/lib/pricing_plans/plan.rb:641  fetch_stripe_price_record
pricing_plans-0.4.0/lib/pricing_plans/plan.rb:448  currency_symbol
app/views/.../pricing/_plan_card.html.erb:134
```

A pricing page is the single page a business least wants to 500. As it stands, a Stripe outage or an expired/absent API key takes down the page that sells the product — even though the gem already knows how to render a perfectly good fallback.

It also makes the gem awkward in any test or CI environment with no Stripe key, which is the normal case. Note that `price_cache` defaults to `Rails.cache`, and in the Rails test environment that is typically `:null_store`, so the cache never absorbs the call and *every* render hits Stripe.

## Why this is clearly a bug and not a design choice

`currency_symbol` is the only Stripe-touching path in `plan.rb` that does not degrade. Every sibling already does:

- `#price_label` wraps its `Stripe::Price.retrieve` in `begin/rescue StandardError` and falls through to local derivation.
- `#stripe_price_components` ends with `rescue StandardError; nil`, and its caller `#price_components` then falls back to a "Contact" label.

And `currency_symbol` already *has* the right fallback one line below — `PricingPlans.configuration.default_currency_symbol` — reached whenever the lookup returns nil. A raise and a nil mean the same thing to a pricing page; only one of them was handled.

## The fix

```ruby
def currency_symbol
  if stripe_price
    # Try to derive from Stripe API/cache; fall back to default
    begin
      pr = fetch_stripe_price_record(preferred_price_id(:month) || preferred_price_id(:year))
      if pr
        return currency_symbol_from(pr)
      end
    rescue StandardError
      # Stripe unreachable, rate-limited or unconfigured: never take down a pricing page
    end
  end
  PricingPlans.configuration.default_currency_symbol
end
```

### Why the guard goes here and not in `fetch_stripe_price_record`

A rescue in the fetcher would protect every caller in one line, which is tempting, but it is the wrong layer for this codebase:

- The fetcher has no idea what a caller should show when the lookup fails. Every caller's fallback is different — a local `$29/mo` derivation, a `"Contact"` label, a configured default symbol. Deciding "failure means nil" inside the fetcher pushes that policy down to a layer that cannot know it.
- It would collapse "Stripe said this price does not exist" and "we could not reach Stripe" into the same nil. Callers currently can't tell them apart either, but baking that into the fetcher makes the distinction unrecoverable for any future caller that wants it.
- It would be redundant with — and quietly mask — the rescues `#price_label` and `#stripe_price_components` already have, leaving dead handlers behind.

The file's established idiom is that each presentation method rescues and degrades to *its own* sensible fallback. This change makes `currency_symbol` follow that idiom instead of inventing a second one. Per the brief, only one of the two placements was applied.

## Test

`test/price_components_test.rb` gains `test_currency_symbol_falls_back_when_stripe_lookup_raises`, using the file's existing const-stub convention (define a `Stripe` module for the duration of the block, remove it in `ensure`) with a `::Stripe::Price.retrieve` that raises the way a missing key does.

Before the fix it errors with exactly the downstream trace:

```
StandardError: No API key provided
    test/price_components_test.rb:121:in 'Stripe::Price.retrieve'
    lib/pricing_plans/plan.rb:641:in 'PricingPlans::Plan#fetch_stripe_price_record'
    lib/pricing_plans/plan.rb:448:in 'PricingPlans::Plan#currency_symbol'
```

After the fix it passes. Full suite: **554 runs, 1616 assertions, 0 failures, 0 errors, 0 skips**, coverage thresholds met (line 82.61%, branch 66.31%).
