### PR TITLE
Allow declaring both a numeric price and a Stripe price id

### DIFF
--- a/docs/01-define-pricing-plans.md
+++ b/docs/01-define-pricing-plans.md
@@ -493,6 +493,26 @@ end
 
 `stripe_price` accepts String or Hash (e.g., `{ month:, year:, id: }`) and the `pricing_plans` PlanResolver maps against Pay's `subscription.processor_plan`.
 
+### Declaring both a `price` and a `stripe_price`
+
+You can declare both, and it's recommended for paid plans:
+
+```ruby
+plan :pro do
+  price 29
+  stripe_price month: "price_123abc", year: "price_456def"
+end
+```
+
+They answer different questions, so they're not alternatives:
+
+- `stripe_price` is the **billing identity**: what checkout charges, and what a Pay subscription is matched against.
+- `price` is the **local source of truth for display and plan comparison**.
+
+When both are set, the number wins for `price_label`, `price_components`, `currency_symbol` and upgrade/downgrade comparisons, so pricing pages and upgrade CTAs render without a single Stripe API call. Without a numeric price, all of that depends on a live `Stripe::Price.retrieve`; if that fails (Stripe unreachable, missing API key, cold cache), every paid plan compares as $0 and upgrade prompts silently vanish.
+
+`price_string` remains exclusive with both: it's a label ("Contact us"), not a number, so it can't be compared.
+
 
 ## Example: define an enterprise plan
 

--- a/docs/04-views.md
+++ b/docs/04-views.md
@@ -15,7 +15,7 @@ Each `PricingPlans::Plan` responds to:
   - `plan.name`
   - `plan.description`
   - `plan.bullets` → Array of strings
-  - `plan.price_label` → The `price` or `price_string` you've defined for the plan. If `stripe_price` is set and the Stripe gem is available, it auto-fetches the live price from Stripe. You can override or disable this.
+  - `plan.price_label` → The `price` or `price_string` you've defined for the plan. If `stripe_price` is set (and no numeric `price` is declared) and the Stripe gem is available, it auto-fetches the live price from Stripe. You can override or disable this.
   - `plan.cta_text`
   - `plan.cta_url`
   - `plan.metadata` → Optional hash for UI/presentation attributes (icons, colors, badges)

--- a/docs/05-semantic-pricing.md
+++ b/docs/05-semantic-pricing.md
@@ -42,6 +42,7 @@ plan.currency_symbol                       # "$" or derived from Stripe
 Notes:
 
 - If `stripe_price` is configured, we derive cents, currency, and interval from the Stripe Price (and cache it).
+- If a numeric `price` is declared alongside `stripe_price`, the local number wins and no Stripe call is made (the yearly interval is then derived as 12× the monthly number; use `price_components_resolver` if your yearly price is discounted).
 - If `price 0` (free), we return components with `present? == true`, amount 0 and the configured default currency symbol.
 - If only `price_string` is set (e.g., "Contact us"), components return `present? == false`, `label == price_string`.
 
@@ -138,6 +139,8 @@ end
 ## Stripe price labels in `plan.price_label`
 
 By default, if a plan has `stripe_price` configured and the `stripe` gem is present, we auto-fetch the Stripe Price and render a friendly label (e.g., `$29/mo`). This mirrors Pay’s use of Stripe Prices.
+
+Declaring a numeric `price` next to `stripe_price` opts that plan out: the local number is rendered and no Stripe call is made.
 
 
 To disable auto-fetching globally:

--- a/lib/pricing_plans/plan.rb
+++ b/lib/pricing_plans/plan.rb
@@ -301,9 +301,11 @@ module PricingPlans
 
     # Human label to display price in UIs. Prefers explicit string, then numeric, else contact.
     def price_label
-      # Auto-fetch from processor (Stripe) if enabled and plan has stripe_price
+      # Auto-fetch from processor (Stripe) if enabled and plan has stripe_price.
+      # A locally declared numeric price wins: it is the source of truth for
+      # display, and honoring it keeps rendering off the network entirely.
       cfg = PricingPlans.configuration
-      if cfg&.auto_price_labels_from_processor && stripe_price
+      if cfg&.auto_price_labels_from_processor && stripe_price && price.nil?
         begin
           if defined?(::Stripe)
             price_id = stripe_price.is_a?(Hash) ? (stripe_price[:id] || stripe_price[:month] || stripe_price[:year]) : stripe_price
@@ -443,7 +445,9 @@ module PricingPlans
     end
 
     def currency_symbol
-      if stripe_price
+      # A locally declared numeric price is rendered in the configured currency
+      # (see #price_components), so don't ask Stripe when we have one.
+      if stripe_price && price.nil?
         # Try to derive from Stripe API/cache; fall back to default
         begin
           pr = fetch_stripe_price_record(preferred_price_id(:month) || preferred_price_id(:year))
@@ -548,8 +552,12 @@ module PricingPlans
     end
 
     def validate_pricing!
-      pricing_fields = [@price, @price_string, @stripe_price].compact
-      if pricing_fields.size > 1
+      # `price` and `stripe_price` are not alternatives: the number is the local
+      # source of truth for display and plan comparison (resolved with no network
+      # call), while the Stripe id stays the billing identity used by checkout and
+      # by subscription -> plan matching. Only `price_string` remains exclusive,
+      # since it is a label that cannot be compared numerically.
+      if @price_string && (@price || @stripe_price)
         raise ConfigurationError, "Plan #{@key} can only have one of: price, price_string, or stripe_price"
       end
     end

--- a/test/plan_test.rb
+++ b/test/plan_test.rb
@@ -265,6 +265,27 @@ class PlanTest < ActiveSupport::TestCase
     assert_match(/can only have one of: price, price_string, or stripe_price/, error.message)
   end
 
+  def test_pricing_validation_rejects_price_string_with_stripe_price
+    plan = PricingPlans::Plan.new(:enterprise)
+
+    assert_raises(PricingPlans::ConfigurationError) do
+      plan.price_string "Contact us"
+      plan.stripe_price "price_123"
+      plan.validate!
+    end
+  end
+
+  def test_pricing_validation_allows_price_with_stripe_price
+    plan = PricingPlans::Plan.new(:pro)
+    plan.price 29
+    plan.stripe_price month: "price_month_123"
+
+    plan.validate!
+
+    assert_equal 29, plan.price
+    assert_equal "price_month_123", plan.monthly_price_id
+  end
+
   def test_integer_max_refinement
     plan = PricingPlans::Plan.new(:pro)
 

--- a/test/price_components_test.rb
+++ b/test/price_components_test.rb
@@ -114,6 +114,39 @@ class PriceComponentsTest < ActiveSupport::TestCase
     end
   end
 
+  def configure_with_price_and_stripe_ids
+    PricingPlans.configure do |config|
+      config.default_plan = :starter
+      config.plan :starter do
+        price 9
+        stripe_price month: "price_starter_month", year: "price_starter_year"
+      end
+      config.plan :pro do
+        price 29
+        stripe_price month: "price_month_123", year: "price_year_456"
+      end
+    end
+  end
+
+  # Fails loudly on any Stripe access so tests can assert "no network at all".
+  def with_forbidden_stripe_stub
+    calls = []
+    stripe_mod = Module.new
+    price_class = Class.new do
+      define_singleton_method(:retrieve) do |id|
+        calls << id
+        raise StandardError, "Stripe must not be called"
+      end
+    end
+    stripe_mod.const_set(:Price, price_class)
+    Object.const_set(:Stripe, stripe_mod)
+    yield
+    assert_equal [], calls, "expected no Stripe::Price.retrieve calls"
+  ensure
+    Object.send(:remove_const, :Stripe) if defined?(Stripe)
+  end
+
+  # Simulates Stripe being unreachable / unconfigured for a plan that has ONLY a Stripe price id.
   def with_raising_stripe_stub
     stripe_mod = Module.new
     price_class = Class.new do
@@ -133,6 +166,33 @@ class PriceComponentsTest < ActiveSupport::TestCase
     plan = PricingPlans::Registry.plan(:pro)
     with_raising_stripe_stub do
       assert_equal PricingPlans.configuration.default_currency_symbol, plan.currency_symbol
+    end
+  end
+
+  def test_price_components_prefer_numeric_price_over_stripe_id
+    configure_with_price_and_stripe_ids
+    plan = PricingPlans::Registry.plan(:pro)
+    with_forbidden_stripe_stub do
+      pc = plan.monthly_price_components
+      assert_equal true, pc.present?
+      assert_equal 2900, pc.amount_cents
+      assert_equal "$", pc.currency
+      assert_equal 2900, plan.monthly_price_cents
+      assert_equal "$", plan.currency_symbol
+      assert_equal "$29/mo", plan.price_label
+      # Stripe id remains the billing identity
+      assert_equal "price_month_123", plan.monthly_price_id
+    end
+  end
+
+  def test_plan_comparison_needs_no_stripe_call_when_numeric_price_declared
+    configure_with_price_and_stripe_ids
+    starter = PricingPlans::Registry.plan(:starter)
+    pro = PricingPlans::Registry.plan(:pro)
+    with_forbidden_stripe_stub do
+      assert pro.upgrade_from?(starter)
+      refute starter.upgrade_from?(pro)
+      assert starter.downgrade_from?(pro)
     end
   end
 
@@ -164,5 +224,3 @@ class PriceComponentsTest < ActiveSupport::TestCase
     PricingPlans.configuration.price_cache = nil
   end
 end
-
-


### PR DESCRIPTION
## The downstream failure mode

`Plan#validate_pricing!` rejected declaring a numeric `price` together with a `stripe_price`:

```
PricingPlans::ConfigurationError: Plan pro can only have one of: price, price_string, or stripe_price
```

But those two are not alternatives:

- `stripe_price` is the **billing identity** — what checkout charges, and what a Pay subscription is matched against to resolve the customer's plan.
- `price` is what the **pricing page renders**, and — the part that bites — what **plan comparison** uses.

So a production app on Stripe price ids (the normal case) has no numeric price. `comparable_price_cents` then falls through `monthly_price_cents` / `yearly_price_cents`, both of which end in `stripe_price_components` → `fetch_stripe_price_record` → a live `Stripe::Price.retrieve`. That method rescues to `nil`, so whenever Stripe is unreachable, un-keyed, rate-limited, or simply cache-cold-and-failing:

- `comparable_price_cents` returns **0 for every paid plan**
- `upgrade_from?` becomes `0 > 0` → false, for all of them
- `next_upgrade_plan` returns nil
- **every upgrade prompt in the host app silently disappears**

Nothing raises, nothing is logged. The funnel just stops asking for money.

The same coupling makes the gem awkward to test in a host app: `price_cache` defaults to `Rails.cache`, which in Rails' test env is typically `:null_store`, so nothing is ever cached and every single render attempts a live Stripe call.

## The change

Declaring both is now legal, with a clear precedence rule:

> **The numeric `price` is the local source of truth for display and comparison. The Stripe id remains the billing identity.**

- `validate_pricing!` now only rejects `price_string` combined with either of the others. `price_string` stays exclusive because it is a label ("Contact us"), not a comparable number — that invariant is unchanged and still covered by its existing test.
- `price_components` already preferred a numeric price over a Stripe lookup (step 3 before step 4) — verified, unchanged.
- `price_label` skipped straight to a live `Stripe::Price.retrieve` when `auto_price_labels_from_processor` is on (the default) and `stripe_price` is set. It now honors a locally declared number first. The `return "Contact" if stripe_price || price.nil?` line needed no change: `return "$#{price}/mo" if price` already short-circuits ahead of it, so a plan with both renders its number, not "Contact".
- `currency_symbol` likewise no longer asks Stripe when a numeric price is present, since `price_components` renders that number in `config.default_currency_symbol` — this keeps the two from disagreeing.

Both display guards only alter behaviour for plans declaring *both*, which was impossible before this PR, so single-declaration plans are untouched.

Net effect: a plan with `price 29` + `stripe_price month: "price_...", year: "price_..."` renders its pricing page and resolves upgrade/downgrade comparisons with **zero network calls**, while checkout and Pay subscription matching keep using the Stripe ids.

## Not changed (deliberately)

- `free?` still returns false when `stripe_price` is set, even with `price 0`. Contradictory to declare, and out of scope.
- `price_components` derives the yearly figure as 12× the monthly number when a numeric price is declared. An app with a discounted yearly price should either omit the numeric price or use `price_components_resolver`. Documented.
- `PricingPlans.plans` sorting now orders these plans by their numeric price instead of bucketing them at the end with contact-us plans — a consequence of the number existing, and an improvement.

## Tests

- a plan may declare both and configuration validates
- with both declared, `price_label`, `price_components`, `currency_symbol`, `comparable_price_cents` / `upgrade_from?` / `downgrade_from?` all work with **no Stripe call at all** — asserted with a const-stub whose `Stripe::Price.retrieve` records the call and raises, following the suite's existing stub convention
- `price_string` + `stripe_price` still raises; existing single-declaration tests unchanged

Each new behavioural test fails on main and passes here. Full suite green: **557 runs, 1630 assertions, 0 failures, 0 errors** (coverage gates pass on a cleared `coverage/`).

## Related

Related to but independent of #24 (`Plan#currency_symbol` rescuing Stripe failures). That PR keeps a pricing page from 500ing when Stripe raises; this one removes the need to call Stripe for display and comparison in the first place. Branched off `main`, not stacked — they touch `currency_symbol` in adjacent lines but neither depends on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDv54tDMnaHGmtd11T8T7i